### PR TITLE
fix(ci): nested population_json_files

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -131,7 +131,7 @@ jobs:
             apt-get update &&
             apt-get install -y google-cloud-sdk &&
             mkdir -p dist/data/population_json_files/ &&
-            gsutil -m cp -r gs://s-locator/misc/population_json_files dist/data/population_json_files/
+            gsutil -m cp -r gs://s-locator/misc/population_json_files/* dist/data/population_json_files/
           "
           echo "Population data retrieval completed."
           


### PR DESCRIPTION
fixed nested `population_json_files` by adding `/*` which copies the content of `population_json_files` inside `population_json_files` instead of copying the directory itself